### PR TITLE
Added type='button' to all buttons in UI

### DIFF
--- a/src/settingsView.js
+++ b/src/settingsView.js
@@ -22,9 +22,9 @@ export const settingsView = ({ element, listeners, direction, rows, cols, autoSe
       "<span> &times; </span> " +
       "<input title='Number of columns' id='" + C.colsId + "' type='text' size='2'" +
         " value='" + cols + "'/>" +
-      "<button id='" + C.hideTracerId + "'>Hide</button>" +
+      "<button id='" + C.hideTracerId + "' type='button'>Hide</button>" +
     "</div>" +
-    "<button id='" + C.showTracerId + "' style='display:none'>Show</button>"
+    "<button id='" + C.showTracerId + "' type='button' style='display:none'>Show</button>"
 
   document.getElementById(C.hideTracerId).addEventListener("click", _evt => {
     listeners.onHideTracer()

--- a/src/streamView.js
+++ b/src/streamView.js
@@ -11,23 +11,23 @@ export const streamView = ({ element, index, listeners, label = "", rows, cols, 
           "<input id='" + C.histId(index) + "' type='checkbox' " + (hist ? "checked" : "") + " />" +
           " Hist " +
         "</label>" +
-        "<button id='" + C.hideStreamId(index) + "'>Hide</button>" +
+        "<button id='" + C.hideStreamId(index) + "' type='button'>Hide</button>" +
       "</div>" +
       "<textarea id='" + C.modelId(index) + "' rows='" + rows + "' cols='" + cols + "'>" +
       "</textarea>" +
       "<div>" +
         "<input id='" + C.sliderId(index) + "' type='range' min='0' max='0' value='0'" +
           " style='width: 100%' />" +
-        "<button id='" + C.stepBackId(index) + "'>&lt</button> " +
-        "<button id='" + C.stepForwardId(index) + "'>&gt</button> " +
+        "<button id='" + C.stepBackId(index) + "' type='button'>&lt</button> " +
+        "<button id='" + C.stepForwardId(index) + "' type='button'>&gt</button> " +
         "<span id='" + C.sliderValueId(index) + "'>-1</span> " +
-        "<button id='" + C.sendId(index) + "'>Send</button> " +
-        "<button id='" + C.resetId(index) + "'>Reset</button> " +
+        "<button id='" + C.sendId(index) + "' type='button'>Send</button> " +
+        "<button id='" + C.resetId(index) + "' type='button'>Reset</button> " +
       "</div>" +
     "</div>" +
     "<div id='" + C.hiddenStreamId(index) + "' style='display:none'>" +
       "<span>" + label + " </span>" +
-      "<button id='" + C.showStreamId(index) + "'>Show</button>" +
+      "<button id='" + C.showStreamId(index) + "' type='button'>Show</button>" +
     "</div>"
 
   document.getElementById(C.sliderId(index)).addEventListener("input", evt => {


### PR DESCRIPTION
While using the tracer on a page utilizing forms, I was unable to press any buttons on the tracer without submitting the page.

Patch should prevent this issue from persisting.

*untested locally*