### PR TITLE
Add cross-env devDep. for setting NODE_ENV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2127,6 +2127,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "unpkg": "dist/meiosis-tracer.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "start": "webpack && NODE_ENV=prod webpack && NODE_ENV=dev webpack && NODE_ENV=devtool webpack",
+    "start": "webpack && cross-env NODE_ENV=prod webpack && cross-env NODE_ENV=dev webpack && cross-env NODE_ENV=devtool webpack",
     "test": "tead",
     "test-watch": "tead --watch"
   },
@@ -32,6 +32,7 @@
     "@babel/preset-env": "^7.10.4",
     "babel-loader": "^8.1.0",
     "browser-env": "^3.3.0",
+    "cross-env": "^7.0.2",
     "eslint": "^7.4.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",


### PR DESCRIPTION
I am not sure if you want to add another devDependency, but `npm start` does not work on a windows machine. I cannot test other machines, but it would seem like `cross-env` is suppose to make it work when setting environment variables. This was an easy change so I thought I would go ahead and make it for you to review.